### PR TITLE
Promise.resolve・Promise.rejectの練習

### DIFF
--- a/kintone-js/self-practice.js
+++ b/kintone-js/self-practice.js
@@ -1,9 +1,73 @@
-{
-  ("use strict");
-  kintone.events.on("app.record.index.show", (event) => {
-    window.alert("Welcome!");
+("use strict");
+// 「案件管理アプリ」:
+
+// イベントオブジェクトを出力
+kintone.events.on("app.record.detail.show", (event) => {
+  console.log(event);
+});
+
+// 提案プランの値を"Cプラン"にする
+kintone.events.on("app.record.edit.show", (event) => {
+  event.record.提案プラン.value = "Cプラン";
+  return event;
+});
+
+//フィールドの編集可／不可切り替え
+(() => {
+  kintone.events.on(
+    ["app.record.create.change.進捗状況", "app.record.edit.change.進捗状況"],
+    (event) => {
+      if (event.record["進捗状況"].value === "受注") {
+        event.record["プラン費用"].disabled = true;
+        event.record["オプション費用"].disabled = true;
+      } else {
+        event.record["プラン費用"].disabled = false;
+        event.record["オプション費用"].disabled = false;
+      }
+      return event;
+    }
+  );
+})();
+
+// フィールドの自動入力
+(() => {
+  kintone.events.on(
+    // 「保存ボタン時」初回商談日を取得し、２週間後の値を算出
+    ["app.record.create.submit", "app.record.edit.submit"],
+    (event) => {
+      const date = dayjs(event.record.初回商談日.value);
+      const planDate = date.add(2, "week").format("YYYY年MM月DD日");
+      // 詳細の値を取得し、planDateを追記
+      const orderDate = event.record.詳細.value + planDate;
+      event.record.詳細.value = orderDate;
+      return event;
+    }
+  );
+})();
+
+// フィールドの表示・非表示
+(() => {
+  const events = [
+    "app.record.create.show",
+    "app.record.edit.change.オプション",
+  ];
+
+  kintone.events.on(events, (event) => {
+    // なにも選択されていなかった場合は「その他」フィールドを表示しない
+    const option = event.record.オプション.value;
+    if (option.length === 0) {
+      kintone.app.record.setFieldShown("その他", false);
+    }
+
+    // 「その他」が選択された場合は「その他」フィールドを表示する
+    option.forEach((element) => {
+      if (element === "その他") {
+        kintone.app.record.setFieldShown("その他", true);
+      } else {
+        kintone.app.record.setFieldShown("その他", false);
+      }
+    });
+
+    return event;
   });
-}
-{
-  console.log("ようこそ！kintoneへ");
-}
+})();

--- a/kintone-js/selt-practice.html
+++ b/kintone-js/selt-practice.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>ようこそ！kintoneへ</title>
+    <title>ようこそ!kintoneへ</title>
     <style>
       body {
         color: white;

--- a/src/async2.test.js
+++ b/src/async2.test.js
@@ -38,5 +38,60 @@ test("Promiseの例外", () => {
 //▲
 
 //▼2024/08/22 「Promiseと例外~」
-test("Promiseの例外", () => {});
+//0)状態が変化済のPromise
+test("状態が変化済のPromise.resolve", () => {
+  //成功
+  const resolvedPromise = Promise.resolve("すでに成功");
+  return expect(resolvedPromise).resolves.toBe("すでに成功");
+});
+test("状態が変化済のPromise.reject", () => {
+  //失敗
+  const rejectedPromise = Promise.reject("すでに失敗");
+  return expect(rejectedPromise).rejects.toBe("すでに失敗");
+});
+
+// 1)Promise.resolve　を呼び出して動きを確認する
+//    ∟Promise.resolveとは？…すぐに成功するPromiseを作るための方法。値を渡すこともできる。
+test("Promise.resolveの練習", () => {
+  return expect(Promise.resolve(123)).resolves.toBe(123);
+});
+
+// 2)Promise.resolve 1から初めてプロミスチェーンで10まで増やす。
+test("Promise.resolveの練習", () => {
+  const promise = Promise.resolve(1);
+  const complete = promise
+    .then((num) => {
+      return num + 2; //3
+    })
+    .then((num) => {
+      return num + 3; //6
+    })
+    .then((num) => {
+      return num + 4; //10
+    });
+  return expect(complete).resolves.toBe(10);
+});
+
+// 3)Promise.reject を呼び出して動きを確認する
+test("Promise.rejectの練習", () => {
+  return expect(Promise.reject(new Error("エラー"))).rejects.toThrow("エラー");
+});
+
+// 4)Promise.rejectからcatchなどで動きを確認する
+// Promise.rejectからプロミスチェーンを使って失敗状態のメソッドをチェーンする
+test("Promise.rejectの練習", () => {
+  const promise = Promise.reject(new Error("初期エラー"));
+  const errorStep = promise
+    .catch((error) => {
+      console.log(error.message);
+      return Promise.reject(new Error("次のエラー"));
+    })
+    .catch((error) => {
+      console.log(error.message);
+      return Promise.reject(new Error("最終エラー"));
+    });
+
+  return expect(errorStep).rejects.toThrow("最終エラー");
+});
+
 //▲


### PR DESCRIPTION
1. Promise.resolveの練習
　- Promise.resolve　を呼び出して動きを確認する
　- Promise.resolve(1) から初めてプロミスチェーンを使って10まで増やす
　　　∟Promise.resolve(1).then(n => n + 1).then(n => n + 2) ...

2. Promise.reject を呼び出して動きを確認する
　- Promise.rejectからcatchなどで動きを確認する
　- Promise.rejectからプロミスチェーンを使って失敗状態のメソッドをチェーンする
　　　∟Promise.reject(new Error()).catch(err => Promise.reject(err)) ...
　　　∟Promise.reject(new Error()).catch(err => {console.log(err)}).then(....)